### PR TITLE
Move constants into own package

### DIFF
--- a/auto/auto.go
+++ b/auto/auto.go
@@ -24,9 +24,9 @@ import (
 
 // Detect sequentially runs resource detection from environment varibales, AWS, and GCP.
 func Detect(ctx context.Context) (*resource.Resource, error) {
-	return resource.DetectAll(ctx,
-		resource.FromEnvVars,
+	return resource.ChainedDetector(
+		resource.FromEnv,
 		gcp.DetectGCEInstance,
 		aws.DetectEC2Instance,
-	)
+	)(ctx)
 }

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -17,7 +17,7 @@ package aws
 import (
 	"context"
 
-	rkeys "contrib.go.opencensus.io/resource"
+	"contrib.go.opencensus.io/resource/resourcekeys"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"go.opencensus.io/resource"
@@ -33,11 +33,11 @@ func DetectEC2Instance(context.Context) (*resource.Resource, error) {
 		return nil, err
 	}
 	return &resource.Resource{
-		Type: rkeys.AWSTypeEC2Instance,
+		Type: resourcekeys.AWSTypeEC2Instance,
 		Tags: map[string]string{
-			rkeys.AWSKeyEC2Region:     doc.Region,
-			rkeys.AWSKeyEC2AccountID:  doc.AccountID,
-			rkeys.AWSKeyEC2InstanceID: doc.InstanceID,
+			resourcekeys.AWSKeyEC2Region:     doc.Region,
+			resourcekeys.AWSKeyEC2AccountID:  doc.AccountID,
+			resourcekeys.AWSKeyEC2InstanceID: doc.InstanceID,
 		},
 	}, nil
 }

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -17,15 +17,10 @@ package aws
 import (
 	"context"
 
+	rkeys "contrib.go.opencensus.io/resource"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"go.opencensus.io/resource"
-)
-
-const (
-	KeyAccountID  = "aws.com/account_id"
-	KeyRegion     = "aws.com/region"
-	KeyInstanceID = "aws.com/ec2/instance_id"
 )
 
 func DetectEC2Instance(context.Context) (*resource.Resource, error) {
@@ -38,11 +33,11 @@ func DetectEC2Instance(context.Context) (*resource.Resource, error) {
 		return nil, err
 	}
 	return &resource.Resource{
-		Type: "aws.com/ec2/instance",
+		Type: rkeys.AWSTypeEC2Instance,
 		Tags: map[string]string{
-			KeyRegion:     doc.Region,
-			KeyAccountID:  doc.AccountID,
-			KeyInstanceID: doc.InstanceID,
+			rkeys.AWSKeyEC2Region:     doc.Region,
+			rkeys.AWSKeyEC2AccountID:  doc.AccountID,
+			rkeys.AWSKeyEC2InstanceID: doc.InstanceID,
 		},
 	}, nil
 }

--- a/const.go
+++ b/const.go
@@ -1,0 +1,31 @@
+package resource
+
+// Constants for Kubernetes resources.
+const (
+	K8STypeContainer = "k8s.io/container"
+
+	K8SKeyNamespaceName = "k8s.io/namespace/name"
+	K8SKeyPodName       = "k8s.io/pod/name"
+	K8SKeyContainerName = "k8s.io/container/name"
+)
+
+// Constants for AWS resources.
+const (
+	AWSTypeEC2Instance = "aws.com/ec2/instance"
+
+	AWSKeyEC2AccountID  = "aws.com/ec2/account_id"
+	AWSKeyEC2Region     = "aws.com/ec2/region"
+	AWSKeyEC2InstanceID = "aws.com/ec2/instance_id"
+)
+
+// Constants for GCP resources.
+const (
+	GCPTypeGCEInstance = "cloud.google.com/gce/instance"
+
+	// ProjectID of the GCE VM. This is not the project ID of the used client credentials.
+	GCPKeyGCEProjectID  = "cloud.google.com/gce/project_id"
+	GCPKeyGCEZone       = "cloud.google.com/gce/zone"
+	GCPKeyGCEInstanceID = "cloud.google.com/gce/instance_id"
+	// Key for the node attribute that's automatically set with the GKE cluster name.
+	GCPKeyGCEClusterName = "cloud.google.com/gce/attributes/cluster_name"
+)

--- a/gcp/gcp.go
+++ b/gcp/gcp.go
@@ -50,12 +50,6 @@ func DetectGCEInstance(context.Context) (*resource.Resource, error) {
 		res.Tags[resourcekeys.GCPKeyGCEZone] = zone
 	}
 
-	clusterName, err := metadata.InstanceAttributeValue("cluster-name")
-	logError(err)
-	if clusterName != "" {
-		res.Tags[resourcekeys.GCPKeyGCEClusterName] = strings.TrimSpace(clusterName)
-	}
-
 	return res, nil
 }
 

--- a/gcp/gcp.go
+++ b/gcp/gcp.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 
 	"cloud.google.com/go/compute/metadata"
-	rkeys "contrib.go.opencensus.io/resource"
+	"contrib.go.opencensus.io/resource/resourcekeys"
 	"go.opencensus.io/resource"
 )
 
@@ -29,31 +29,31 @@ func DetectGCEInstance(context.Context) (*resource.Resource, error) {
 		return nil, nil
 	}
 	res := &resource.Resource{
-		Type: rkeys.GCPTypeGCEInstance,
+		Type: resourcekeys.GCPTypeGCEInstance,
 		Tags: map[string]string{},
 	}
 	instanceID, err := metadata.InstanceID()
 	logError(err)
 	if instanceID != "" {
-		res.Tags[rkeys.GCPKeyGCEInstanceID] = instanceID
+		res.Tags[resourcekeys.GCPKeyGCEInstanceID] = instanceID
 	}
 
 	projectID, err := metadata.ProjectID()
 	logError(err)
 	if projectID != "" {
-		res.Tags[rkeys.GCPKeyGCEProjectID] = projectID
+		res.Tags[resourcekeys.GCPKeyGCEProjectID] = projectID
 	}
 
 	zone, err := metadata.Zone()
 	logError(err)
 	if zone != "" {
-		res.Tags[rkeys.GCPKeyGCEZone] = zone
+		res.Tags[resourcekeys.GCPKeyGCEZone] = zone
 	}
 
 	clusterName, err := metadata.InstanceAttributeValue("cluster-name")
 	logError(err)
 	if clusterName != "" {
-		res.Tags[rkeys.GCPKeyGCEClusterName] = strings.TrimSpace(clusterName)
+		res.Tags[resourcekeys.GCPKeyGCEClusterName] = strings.TrimSpace(clusterName)
 	}
 
 	return res, nil

--- a/gcp/gcp.go
+++ b/gcp/gcp.go
@@ -20,14 +20,8 @@ import (
 	"strings"
 
 	"cloud.google.com/go/compute/metadata"
+	rkeys "contrib.go.opencensus.io/resource"
 	"go.opencensus.io/resource"
-)
-
-const (
-	KeyProjectID   = "cloud.google.com/project_id"
-	KeyZone        = "cloud.google.com/zone"
-	KeyInstanceID  = "cloud.google.com/gce/instance_id"
-	KeyClusterName = "cloud.google.com/gce/attributes/cluster_name"
 )
 
 func DetectGCEInstance(context.Context) (*resource.Resource, error) {
@@ -35,31 +29,31 @@ func DetectGCEInstance(context.Context) (*resource.Resource, error) {
 		return nil, nil
 	}
 	res := &resource.Resource{
-		Type: "cloud.google.com/gce/instance",
+		Type: rkeys.GCPTypeGCEInstance,
 		Tags: map[string]string{},
 	}
 	instanceID, err := metadata.InstanceID()
 	logError(err)
 	if instanceID != "" {
-		res.Tags[KeyInstanceID] = instanceID
+		res.Tags[rkeys.GCPKeyGCEInstanceID] = instanceID
 	}
 
 	projectID, err := metadata.ProjectID()
 	logError(err)
 	if projectID != "" {
-		res.Tags[KeyProjectID] = projectID
+		res.Tags[rkeys.GCPKeyGCEProjectID] = projectID
 	}
 
 	zone, err := metadata.Zone()
 	logError(err)
 	if zone != "" {
-		res.Tags[KeyZone] = zone
+		res.Tags[rkeys.GCPKeyGCEZone] = zone
 	}
 
 	clusterName, err := metadata.InstanceAttributeValue("cluster-name")
 	logError(err)
 	if clusterName != "" {
-		res.Tags[KeyClusterName] = strings.TrimSpace(clusterName)
+		res.Tags[rkeys.GCPKeyGCEClusterName] = strings.TrimSpace(clusterName)
 	}
 
 	return res, nil

--- a/resourcekeys/const.go
+++ b/resourcekeys/const.go
@@ -19,6 +19,11 @@ package resourcekeys
 const (
 	K8STypeContainer = "k8s.io/container"
 
+	// A uniquely identifying name for the Kubernetes cluster. Kubernetes
+	// does not have cluster names as an internal concept so this may be
+	// set to any meaningful value within the environment. For example,
+	// GKE clusters have a name which can be used for this label.
+	K8SKeyClusterName   = "k8s.io/cluster/name"
 	K8SKeyNamespaceName = "k8s.io/namespace/name"
 	K8SKeyPodName       = "k8s.io/pod/name"
 	K8SKeyContainerName = "k8s.io/container/name"
@@ -41,6 +46,4 @@ const (
 	GCPKeyGCEProjectID  = "cloud.google.com/gce/project_id"
 	GCPKeyGCEZone       = "cloud.google.com/gce/zone"
 	GCPKeyGCEInstanceID = "cloud.google.com/gce/instance_id"
-	// Key for the node attribute that's automatically set with the GKE cluster name.
-	GCPKeyGCEClusterName = "cloud.google.com/gce/attributes/cluster_name"
 )

--- a/resourcekeys/const.go
+++ b/resourcekeys/const.go
@@ -1,4 +1,19 @@
-package resource
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package resourcekeys contains well known type and label keys for resources.
+package resourcekeys
 
 // Constants for Kubernetes resources.
 const (


### PR DESCRIPTION
@rakyll @rghetia We want to use the constants in exporters as well to implement their mapping for the standard resources. To avoid every exporter transitively importing all cloud provider SDKs and such, I opted for a separate file.

The only potential problem I see is that `contrib.go.opencensus.io/resource` collides with `go.opencensus.io/resource` and exporters will have to opt for import path renaming. Nothing too bad in general but maybe you've idea for alternative descriptive names (i.e. not `package consts`).